### PR TITLE
Add init time profiling draft

### DIFF
--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -160,7 +160,7 @@ target_link_libraries(
 )
 target_link_libraries(
   qnn_context PRIVATE qnn_implementation qnn_logger qnn_backend qnn_device
-                      qnn_backend_cache
+                      qnn_backend_cache qnn_profiler
 )
 target_link_libraries(
   qnn_graph PRIVATE qnn_executorch_logging qnn_implementation qnn_context

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -175,7 +175,7 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
   auto end = std::chrono::high_resolution_clock::now();
   auto int_s = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-  std::cout << "[NEW ADDED] Init Time: " << int_s.count() << " milliseconds"
+  std::cout << "[Time consuming during init in QnnBackend] Init Time: " << int_s.count() << " milliseconds"
             << std::endl;
   ET_CHECK_OR_RETURN_ERROR(
         qnn_manager->ProfileInitData() == Error::Ok,

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -11,6 +11,8 @@
 #include <executorch/backends/qualcomm/runtime/QnnExecuTorchBackend.h>
 #include <executorch/backends/qualcomm/runtime/QnnManager.h>
 #include <executorch/backends/qualcomm/schema_generated.h>
+#include <chrono>
+#include <iostream>
 namespace torch {
 namespace executor {
 // ========== Public method implementations =========================
@@ -21,6 +23,7 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
     BackendInitContext& context,
     FreeableBuffer* processed,
     ArrayRef<CompileSpec> compile_specs) const {
+  auto start = std::chrono::high_resolution_clock::now();
   // covert SizedBuffer to qnn ExecuTorch option
   QnnExecuTorchContextBinary qnn_context_blob;
   const qnn_delegate::QnnExecuTorchOptions* qnn_executorch_options = nullptr;
@@ -169,6 +172,15 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
         Internal,
         "Fail to allocate tensor");
   }
+  auto end = std::chrono::high_resolution_clock::now();
+  auto int_s = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  std::cout << "[NEW ADDED] Init Time: " << int_s.count() << " milliseconds"
+            << std::endl;
+  ET_CHECK_OR_RETURN_ERROR(
+        qnn_manager->ProfileInitData() == Error::Ok,
+        Internal,
+        "Fail to allocate tensor");
   return qnn_manager;
 }
 

--- a/backends/qualcomm/runtime/QnnManager.cpp
+++ b/backends/qualcomm/runtime/QnnManager.cpp
@@ -418,6 +418,20 @@ Error QnnManager::ProfileExecuteData(EventTracer* event_tracer) {
   return Error::Ok;
 }
 
+Error QnnManager::ProfileInitData() {
+  Qnn_ErrorHandle_t error = QNN_SUCCESS;
+  if (options_->profile_level() != QnnExecuTorchProfileLevel::kProfileOff) {
+    error =
+        backend_params_ptr_->qnn_context_ptr_->ProfileInitData();
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_ERROR(
+          " Failed to profile. Error %d", QNN_GET_ERROR_CODE(error));
+      return Error::Internal;
+    }
+  }
+  return Error::Ok;
+}
+
 void QnnManager::Destroy() {
   QNN_EXECUTORCH_LOG_INFO("Destroy Qnn backend parameters");
   backend_params_ptr_.reset(new BackendConfigParameters());

--- a/backends/qualcomm/runtime/QnnManager.h
+++ b/backends/qualcomm/runtime/QnnManager.h
@@ -41,6 +41,7 @@ class QnnManager {
       EventTracer* event_tracer);
 
   Error ProfileExecuteData(EventTracer* event_tracer);
+  Error ProfileInitData();
 
   void Destroy();
 

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
@@ -61,6 +61,7 @@ std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
           backend_params->qnn_backend_ptr_.get(),
           backend_params->qnn_device_ptr_.get(),
           qnn_context_blob,
+          options->profile_level(),
           htp_options);
 
       backend_params->qnn_graph_ptr_ = std::make_unique<HtpGraph>(

--- a/backends/qualcomm/runtime/backends/QnnContextCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnContextCommon.cpp
@@ -15,7 +15,7 @@ QnnContext::~QnnContext() {
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
   if (handle_ != nullptr) {
     QNN_EXECUTORCH_LOG_INFO("Destroy Qnn context");
-    error = qnn_interface.qnn_context_free(handle_, /*profile=*/nullptr);
+    error = qnn_interface.qnn_context_free(handle_, profile_->GetHandle());
     if (error != QNN_SUCCESS) {
       QNN_EXECUTORCH_LOG_ERROR(
           "Failed to free QNN "
@@ -32,6 +32,8 @@ Error QnnContext::Configure() {
   // create qnn context
   const QnnInterface& qnn_interface = implementation_.GetQnnInterface();
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
+  profile_ =
+      std::make_unique<QnnProfile>(implementation_, backend_, profile_level_);
 
   std::vector<const QnnContext_Config_t*> temp_context_config;
   ET_CHECK_OR_RETURN_ERROR(
@@ -49,7 +51,7 @@ Error QnnContext::Configure() {
         qnn_context_blob.buffer,
         qnn_context_blob.nbytes,
         &handle_,
-        /*profile=*/nullptr);
+        profile_->GetHandle());
     if (error != QNN_SUCCESS) {
       QNN_EXECUTORCH_LOG_ERROR(
           "Can't create context from "

--- a/backends/qualcomm/runtime/backends/QnnContextCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnContextCommon.h
@@ -11,6 +11,7 @@
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCache.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnBackendCommon.h>
 #include <executorch/backends/qualcomm/runtime/backends/QnnDeviceCommon.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnProfiler.h>
 
 #include <memory>
 namespace torch {
@@ -22,16 +23,21 @@ class QnnContext {
       const QnnImplementation& implementation,
       QnnBackend* backend,
       QnnDevice* device,
-      const QnnExecuTorchContextBinary& qnn_context_blob)
+      const QnnExecuTorchContextBinary& qnn_context_blob,
+      const QnnExecuTorchProfileLevel& profile_level)
       : handle_(nullptr),
         implementation_(implementation),
         backend_(backend),
-        device_(device) {
+        device_(device),
+        profile_level_(profile_level) {
     cache_ = std::make_unique<QnnBackendCache>(qnn_context_blob);
   }
 
   virtual ~QnnContext();
   Error Configure();
+  Qnn_ErrorHandle_t ProfileInitData() {
+    return profile_->ProfileData(nullptr);
+  };
 
   Qnn_ContextHandle_t GetHandle() const {
     return handle_;
@@ -68,6 +74,8 @@ class QnnContext {
   QnnBackend* backend_;
   QnnDevice* device_;
   std::unique_ptr<QnnBackendCache> cache_;
+  QnnExecuTorchProfileLevel profile_level_;
+  std::unique_ptr<QnnProfile> profile_;
   std::vector<char> binary_buffer_;
 };
 } // namespace qnn

--- a/backends/qualcomm/runtime/backends/QnnProfiler.cpp
+++ b/backends/qualcomm/runtime/backends/QnnProfiler.cpp
@@ -88,15 +88,21 @@ Qnn_ErrorHandle_t QnnProfile::ProfileData(EventTracer* event_tracer) {
         if (sub_event_data.type == QNN_PROFILE_EVENTTYPE_NODE &&
             (sub_event_data.unit == QNN_PROFILE_EVENTUNIT_MICROSEC ||
              sub_event_data.unit == QNN_PROFILE_EVENTUNIT_CYCLES)) {
-          torch::executor::event_tracer_log_profiling_delegate(
+          if(event_tracer!=nullptr){
+            torch::executor::event_tracer_log_profiling_delegate(
               event_tracer,
               sub_event_data.identifier,
               /*delegate_debug_id=*/
               static_cast<torch::executor::DebugHandle>(-1),
               0,
               sub_event_data.value);
+          }
+          
         }
       }
+    } else {
+      if(event_data.unit == QNN_PROFILE_EVENTUNIT_MICROSEC)
+        QNN_EXECUTORCH_LOG_INFO("Type: %d, Init Event Name: %s, Event Data: %d us", event_data.type, event_data.identifier, event_data.value );
     }
   }
   return error;

--- a/backends/qualcomm/runtime/backends/htpbackend/HtpContext.h
+++ b/backends/qualcomm/runtime/backends/htpbackend/HtpContext.h
@@ -23,8 +23,9 @@ class HtpContext : public QnnContext {
       QnnBackend* backend,
       QnnDevice* device,
       const QnnExecuTorchContextBinary& qnn_context_blob,
+      const QnnExecuTorchProfileLevel& profile_level,
       const QnnExecuTorchHtpBackendOptions* htp_options)
-      : QnnContext(implementation, backend, device, qnn_context_blob) {
+      : QnnContext(implementation, backend, device, qnn_context_blob, profile_level) {
     htp_context_custom_config_ =
         std::make_unique<HtpContextCustomConfig>(this, htp_options);
   }

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -355,7 +355,7 @@ Error Runner::generate(
     stats_.model_load_start_ms = util::time_in_ms();
     ET_CHECK_OK_OR_RETURN_ERROR(load());
     stats_.model_load_end_ms = util::time_in_ms();
-    ET_LOG(Info, "[NEW ADDED] init took %ld ms", stats_.model_load_end_ms-stats_.model_load_start_ms);
+    ET_LOG(Info, "[Time consuming during load() function] init took %ld ms", stats_.model_load_end_ms-stats_.model_load_start_ms);
   }
 
   // First token time only measures the time it takes to encode the prompt and

--- a/examples/models/llama2/main.cpp
+++ b/examples/models/llama2/main.cpp
@@ -355,6 +355,7 @@ Error Runner::generate(
     stats_.model_load_start_ms = util::time_in_ms();
     ET_CHECK_OK_OR_RETURN_ERROR(load());
     stats_.model_load_end_ms = util::time_in_ms();
+    ET_LOG(Info, "[NEW ADDED] init took %ld ms", stats_.model_load_end_ms-stats_.model_load_start_ms);
   }
 
   // First token time only measures the time it takes to encode the prompt and

--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -194,6 +194,7 @@ def get_qnn_partitioner(
             ),
             debug=False,
             saver=False,
+            profile=True,
         ),
         skip_node_id_set={},
         skip_node_op_set=skip_node_op_set,


### PR DESCRIPTION
This PR is to show some init time related log at runtime.

1. This is all init time on the QnnBackend.
```[Time consuming during init in QnnBackend] Init Time: 219 milliseconds```
2. It is generated from qnn profiling. 
`QNN (load binary) time` includes `RPC (load binary) time`.
`RPC (load binary) time` includes `QNN accelerator (load binary) time`.
`QNN accelerator (load binary) time` includes `Accelerator (load binary) time`.
```
[INFO] [Qnn ExecuTorch]: Type: 1002, Init Event Name: RPC (load binary) time, Event Data: 16303 us
[INFO] [Qnn ExecuTorch]: Type: 1003, Init Event Name: QNN accelerator (load binary) time, Event Data: 15899 us
[INFO] [Qnn ExecuTorch]: Type: 1004, Init Event Name: Accelerator (load binary) time, Event Data: 15709 us
[INFO] [Qnn ExecuTorch]: Type: 100, Init Event Name: QNN (load binary) time, Event Data: 53819 us
```
![image](https://github.com/user-attachments/assets/f27eccfe-890c-4990-815a-1dc482dd3f8c)
(refer to qnn docs)
3. This is overall loading time in main.cpp
```
I 00:00:00.386326 executorch:main.cpp:358] [Time consuming during load() function] init took 383 ms
```

